### PR TITLE
feat(diario): adicionar comando /diario para registro de reflexões diárias

### DIFF
--- a/cogs/daily.py
+++ b/cogs/daily.py
@@ -1,0 +1,66 @@
+from discord.ext import commands
+from logging_config import logger
+from database_config import runner_query
+import random
+
+class Daily(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def daily(self, ctx, * ,msg: str,name="$daily"):
+        incentive_phrases = [
+    "Sua mensagem foi registrada: Cada passo conta, mantenha o foco no seu caminho.",
+    "Sua mensagem foi registrada: O progresso está nas pequenas ações diárias. Continue assim!",
+    "Sua mensagem foi registrada: A resiliência é o que fortalece sua jornada. Vamos juntos!",
+    "Sua mensagem foi registrada: Organize-se, o sucesso vem com foco. Continue em frente!",
+    "Sua mensagem foi registrada: Liderança se constrói com ações consistentes. Você está no caminho certo!",
+    "Sua mensagem foi registrada: A cada desafio, você cresce mais. Não pare agora!",
+    "Sua mensagem foi registrada: Foco no objetivo. Estamos cada vez mais perto do sucesso!",
+    "Sua mensagem foi registrada: A jornada é longa, mas sua determinação vai te levar longe."
+]
+        author = ctx.author.mention
+        if ctx.guild is None:
+            if len(msg) <= 501:
+                try:
+                    id_valor = runner_query("SELECT id_valor FROM users WHERE id_discord = ?",name,values=(ctx.author.id,))
+                    if id_valor:
+                        query = '''
+                        INSERT INTO daily (user_id, daily_text)
+                        VALUES (?, ?);
+                        '''
+                        id_valor = id_valor[0][0]
+                        values = (id_valor,msg,)
+                        try:
+                            runner_query(query,name,values)            
+                            await ctx.author.send(f'{random.choice(incentive_phrases)}')
+                        except Exception as e:
+                            logger.warning(e)
+                    else:
+                        query = '''
+                        INSERT INTO users (id_discord, name, qtd_perguntar)
+                        VALUES (?, ?,?);
+                        '''
+                        values = (ctx.author.id, ctx.author.name, 1)
+                        try:
+                            runner_query(query,name,values)
+                        except Exception as e:
+                            logger.info(e)
+                    
+                except Exception as e:
+                    logger.warning(f"Não foi possivel enviar mensagem no privado: {e}")
+                    await ctx.send(f"{ctx.author.mention}, não consegui te mandar uma DM. Verifique suas configurações de privacidade.")
+            else:
+                logger.info("Usuário tentou enviar mais de 500 caracteres")
+                await ctx.author.send(f'{author}, por favor mantenha a mensagem com menos de 500 caracteres')
+        else:
+            logger.info(f'Comando foi chamado a partir de um canal publico: {ctx.guild}')
+            try:
+                await ctx.message.delete()
+                await ctx.author.send(f'{author}, você usou o comando Daily em um canal publico, use apenas no chat privado')
+                logger.info('Mensagem excluida')
+            except Exception as e:
+                logger.warning(f"Falha: {e}")
+        
+async def setup(bot):   
+    await bot.add_cog(Daily(bot))

--- a/cogs/daily.py
+++ b/cogs/daily.py
@@ -31,21 +31,16 @@ class Daily(commands.Cog):
                         '''
                         id_valor = id_valor[0][0]
                         values = (id_valor,msg,)
-                        try:
-                            runner_query(query,name,values)            
-                            await ctx.author.send(f'{random.choice(incentive_phrases)}')
-                        except Exception as e:
-                            logger.warning(e)
+                        runner_query(query,name,values)            
+                        await ctx.author.send(f'{random.choice(incentive_phrases)}')
                     else:
                         query = '''
                         INSERT INTO users (id_discord, name, qtd_perguntar)
                         VALUES (?, ?,?);
                         '''
                         values = (ctx.author.id, ctx.author.name, 1)
-                        try:
-                            runner_query(query,name,values)
-                        except Exception as e:
-                            logger.info(e)
+                        runner_query(query,name,values)
+
                     
                 except Exception as e:
                     logger.warning(f"Não foi possivel enviar mensagem no privado: {e}")

--- a/database_config.py
+++ b/database_config.py
@@ -31,3 +31,12 @@ users = '''
         create_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 '''  
+daily_db = '''
+CREATE TABLE IF NOT EXISTS daily (
+    id_daily INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    daily_text TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id_valor)
+);
+'''

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,22 @@
+# Estrutura da Base de Dados:
+
+~~~mermaid
+classDiagram
+    class User {
+        +id_valor : int
+        +id_discord : string
+        +name : string
+        +qtd_perguntar : int
+        +create_at : datetime
+    }
+
+    class Daily {
+        +id_daily : int
+        +user_id : int
+        +daily_text : string
+        +created_at : datetime
+    }
+
+    User "1" --> "many" Daily : escreve
+
+~~~

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 from dotenv import load_dotenv  # opcional, se estiver usando .env
 import asyncio
 from logging_config import logger
-from database_config import users, runner_query
+from database_config import users, daily_db, runner_query
 
 # Carrega variáveis de ambiente (caso use .env)
 load_dotenv()
@@ -25,8 +25,11 @@ async def setup(name='setup'):
     await bot.load_extension("cogs.ping")  # aqui você carrega todos os cogs
     await bot.load_extension("cogs.inspire")
     await bot.load_extension("cogs.gpt")
+    await bot.load_extension("cogs.daily")
     logger.info("Criando banco de dados")
+    runner_query("PRAGMA foreign_keys = ON",name)
     runner_query(users,name)
+    runner_query(daily_db,name)
     logger.info("Iniciando bot VALOR...")
     await bot.start(os.getenv("DISCORD_TOKEN"))
 # Executa o setup assíncrono


### PR DESCRIPTION
O comando /diario permite que o usuário registre uma reflexão, aprendizado ou sentimento diário. A mensagem é salva com user_id, data e conteúdo de forma privada. Implementado armazenamento local e verificação de limite de caracteres.
Closes #2