### PR TITLE
Add ScoutGuard Azure DevOps task to run Docker Scout and save CVE JSON

### DIFF
--- a/ScoutGuard/README.md
+++ b/ScoutGuard/README.md
@@ -1,0 +1,49 @@
+# ScoutGuard
+
+A **ScoutGuard** é uma extensão do Azure DevOps que adiciona uma task para executar o Docker Scout após o `docker build`, gerando um relatório JSON de CVEs.
+
+## Conteúdo
+
+- Task do Azure DevOps para rodar `docker scout cves`.
+- Instalação automática do Docker Scout (opcional).
+- Exporta o caminho do relatório via variável `ScoutGuardReportPath`.
+
+## Pré-requisitos
+
+- Docker instalado no agente.
+- Acesso à internet se precisar instalar o Docker Scout.
+
+## Inputs da task
+
+| Input | Obrigatório | Descrição |
+| --- | --- | --- |
+| `imageName` | Sim | Nome/tag da imagem Docker (ex: `minha-imagem:latest`). |
+| `outputPath` | Sim | Caminho para salvar o JSON (relativo ao workspace ou absoluto). |
+| `installScout` | Sim | Instala o Docker Scout automaticamente se necessário. |
+| `additionalArgs` | Não | Argumentos extras para `docker scout cves`. |
+
+## Exemplo de uso (YAML)
+
+```yaml
+- task: ScoutGuard@0
+  inputs:
+    imageName: 'minha-imagem:latest'
+    outputPath: '$(Build.ArtifactStagingDirectory)/scout-report.json'
+    installScout: true
+```
+
+## Empacotar
+
+```bash
+npm install
+npm install -g tfx-cli
+cd ScoutGuard
+npm install --prefix tasks/scoutguard
+npx tfx extension create --manifest-globs vss-extension.json
+```
+
+## Publicar
+
+```bash
+npx tfx extension publish --vsix scoutguard-0.1.0.vsix --publisher seu-publicador
+```

--- a/ScoutGuard/images/scoutguard-icon.svg
+++ b/ScoutGuard/images/scoutguard-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#0b5cab"/>
+  <path d="M64 24l32 12v24c0 22.1-13.9 42-32 48-18.1-6-32-25.9-32-48V36l32-12z" fill="#ffffff"/>
+  <path d="M64 40c11 0 20 9 20 20s-9 20-20 20-20-9-20-20 9-20 20-20z" fill="#0b5cab"/>
+  <path d="M64 50c5.5 0 10 4.5 10 10s-4.5 10-10 10-10-4.5-10-10 4.5-10 10-10z" fill="#ffffff"/>
+</svg>

--- a/ScoutGuard/tasks/scoutguard/index.js
+++ b/ScoutGuard/tasks/scoutguard/index.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync, execSync } = require('child_process');
+const tl = require('azure-pipelines-task-lib/task');
+
+function resolveOutputPath(outputPath) {
+  if (path.isAbsolute(outputPath)) {
+    return outputPath;
+  }
+  const defaultWorkingDirectory = tl.getVariable('System.DefaultWorkingDirectory');
+  const baseDir = defaultWorkingDirectory || process.cwd();
+  return path.resolve(baseDir, outputPath);
+}
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr || '';
+    const stdout = result.stdout || '';
+    throw new Error(`Falha ao executar ${command} ${args.join(' ')}\n${stdout}\n${stderr}`);
+  }
+  return result.stdout;
+}
+
+function scoutAvailable() {
+  const result = spawnSync('docker', ['scout', 'version'], { encoding: 'utf8' });
+  return result.status === 0;
+}
+
+function installScout() {
+  const installUrl = process.env.DOCKER_SCOUT_INSTALL_URL || 'https://raw.githubusercontent.com/docker/scout-cli/main/install.sh';
+  tl.debug(`Instalando Docker Scout usando ${installUrl}`);
+  execSync(`curl -sSfL ${installUrl} | sh -s --`, { stdio: 'inherit' });
+}
+
+function parseAdditionalArgs(rawArgs) {
+  if (!rawArgs) {
+    return [];
+  }
+  return rawArgs
+    .split(' ')
+    .map((arg) => arg.trim())
+    .filter((arg) => arg.length > 0);
+}
+
+async function run() {
+  try {
+    const imageName = tl.getInput('imageName', true);
+    const outputPath = tl.getInput('outputPath', true);
+    const installScoutInput = tl.getBoolInput('installScout', true);
+    const additionalArgsInput = tl.getInput('additionalArgs', false) || '';
+
+    if (!scoutAvailable()) {
+      if (!installScoutInput) {
+        throw new Error('Docker Scout não está disponível e a instalação automática foi desabilitada.');
+      }
+      installScout();
+      if (!scoutAvailable()) {
+        throw new Error('Docker Scout não ficou disponível após a instalação.');
+      }
+    }
+
+    const outputFile = resolveOutputPath(outputPath);
+    const additionalArgs = parseAdditionalArgs(additionalArgsInput);
+    const args = ['scout', 'cves', '--format', 'json', ...additionalArgs, imageName];
+
+    tl.debug(`Executando: docker ${args.join(' ')}`);
+    const output = runCommand('docker', args);
+
+    fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+    fs.writeFileSync(outputFile, output, 'utf8');
+
+    tl.setVariable('ScoutGuardReportPath', outputFile);
+    tl.setResult(tl.TaskResult.Succeeded, `Relatório salvo em ${outputFile}`);
+  } catch (error) {
+    tl.setResult(tl.TaskResult.Failed, error.message);
+  }
+}
+
+run();

--- a/ScoutGuard/tasks/scoutguard/package.json
+++ b/ScoutGuard/tasks/scoutguard/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "scoutguard-task",
+  "version": "0.1.0",
+  "description": "Azure DevOps task para executar o Docker Scout.",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "azure-pipelines-task-lib": "^4.11.0"
+  }
+}

--- a/ScoutGuard/tasks/scoutguard/task.json
+++ b/ScoutGuard/tasks/scoutguard/task.json
@@ -1,0 +1,55 @@
+{
+  "id": "bba14378-0a51-4d15-9f71-25e9e8f8dd6f",
+  "name": "ScoutGuard",
+  "friendlyName": "ScoutGuard - Docker Scout CVEs",
+  "description": "Executa o Docker Scout após o build para gerar um relatório JSON de CVEs.",
+  "author": "ScoutGuard",
+  "helpMarkDown": "Use após o docker build para analisar CVEs na imagem.",
+  "category": "Utility",
+  "visibility": ["Build", "Release"],
+  "version": {
+    "Major": 0,
+    "Minor": 1,
+    "Patch": 0
+  },
+  "instanceNameFormat": "ScoutGuard: $(imageName)",
+  "inputs": [
+    {
+      "name": "imageName",
+      "type": "string",
+      "label": "Nome da imagem",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Nome/tag da imagem Docker (ex: minha-imagem:latest)."
+    },
+    {
+      "name": "outputPath",
+      "type": "string",
+      "label": "Caminho do relatório JSON",
+      "defaultValue": "scout-report.json",
+      "required": true,
+      "helpMarkDown": "Caminho para salvar o JSON. Pode ser relativo ao workspace."
+    },
+    {
+      "name": "installScout",
+      "type": "boolean",
+      "label": "Instalar Docker Scout se não estiver disponível",
+      "defaultValue": "true",
+      "required": true,
+      "helpMarkDown": "Baixa e instala o Docker Scout CLI caso o comando não exista."
+    },
+    {
+      "name": "additionalArgs",
+      "type": "string",
+      "label": "Argumentos adicionais",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Argumentos extras passados ao comando docker scout cves."
+    }
+  ],
+  "execution": {
+    "Node16": {
+      "target": "index.js"
+    }
+  }
+}

--- a/ScoutGuard/vss-extension.json
+++ b/ScoutGuard/vss-extension.json
@@ -1,0 +1,42 @@
+{
+  "manifestVersion": 1,
+  "id": "scoutguard",
+  "name": "ScoutGuard",
+  "publisher": "seu-publicador",
+  "version": "0.1.0",
+  "description": "Task do Azure DevOps para executar o Docker Scout e gerar relatório JSON de CVEs.",
+  "categories": ["Azure Pipelines"],
+  "targets": [
+    {
+      "id": "Microsoft.VisualStudio.Services"
+    }
+  ],
+  "icons": {
+    "default": "images/scoutguard-icon.svg"
+  },
+  "files": [
+    {
+      "path": "tasks/scoutguard"
+    },
+    {
+      "path": "images"
+    },
+    {
+      "path": "README.md"
+    }
+  ],
+  "contributions": [
+    {
+      "id": "scoutguard-task",
+      "type": "ms.vss-distributed-task.task",
+      "targets": [
+        {
+          "id": "ms.vss-distributed-task.tasks"
+        }
+      ],
+      "properties": {
+        "name": "tasks/scoutguard"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide an Azure DevOps task/extension that runs `docker scout cves` after a `docker build` to detect CVEs and produce a JSON report.
- Allow agents without Docker Scout installed to optionally install the Scout CLI automatically.
- Expose the generated report path to pipelines via a variable for downstream consumption.

### Description
- Add extension manifest `vss-extension.json` and README `README.md` to package the `ScoutGuard` extension for Azure DevOps. 
- Add task metadata `tasks/scoutguard/task.json` defining inputs `imageName`, `outputPath`, `installScout`, and `additionalArgs` and `Node16` execution target. 
- Implement task logic in `tasks/scoutguard/index.js` that checks `docker scout` availability, optionally installs Scout via the install script, runs `docker scout cves --format json` with parsed `additionalArgs`, writes the JSON to the resolved `outputPath`, and sets `ScoutGuardReportPath` pipeline variable. 
- Add `tasks/scoutguard/package.json` with the `azure-pipelines-task-lib` dependency and include an SVG icon `images/scoutguard-icon.svg`.

### Testing
- No automated tests were executed as part of this change.
- Manual / packaging steps are documented in `README.md` and `npm install` / `tfx` packaging will be required before publishing the extension.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696faf9365b48320af89719cfc60527c)